### PR TITLE
Use mono-basic package from the archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM frolvlad/alpine-mono
 
 RUN apk add --no-cache --virtual=.build-dependencies wget ca-certificates tar xz && \
-    wget "https://www.archlinux.org/packages/extra/x86_64/mono-basic/download/" -O "/tmp/mono-basic.pkg.tar.xz" && \
+    wget "https://archive.archlinux.org/packages/m/mono-basic/mono-basic-4.6-2-x86_64.pkg.tar.xz" -O "/tmp/mono-basic.pkg.tar.xz" && \
     tar -xJf "/tmp/mono-basic.pkg.tar.xz" && \
     cert-sync /etc/ssl/certs/ca-certificates.crt && \
     apk del .build-dependencies && \


### PR DESCRIPTION
mono-basic package was dropped from Arch Linux repository, but it remains in Arch Linux Archive (ALA)